### PR TITLE
feat: graceful job name fallback with DBT_CLOUD_JOB_ID support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install dbt
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.6] - 2026-02-17
 
 ### Changed
 - `DBT_JOB_NAME` is no longer mandatory. Falls back to `DBT_CLOUD_JOB_ID` (automatic in dbt Cloud), then `UNNAMED_JOB`. A warning is logged when `DBT_JOB_NAME` is not set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `DBT_JOB_NAME` is no longer mandatory. Falls back to `DBT_CLOUD_JOB_ID` (automatic in dbt Cloud), then `UNNAMED_JOB`. A warning is logged when `DBT_JOB_NAME` is not set.
 - Simplified integration test models to be more focused and minimal
 - Streamlined CI workflow configuration following best practices from established dbt packages
 - Removed unnecessary complexity from test SQL models

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A dbt macro-only package (`yuki_snowflake_dbt_tags`) that automatically tags every Snowflake query during a dbt run with JSON-formatted metadata in the `QUERY_TAG` session parameter. Published on dbt Hub. Current version: 0.2.5.
+
+## Commands
+
+All integration test commands run from `integration_tests/` with `DBT_PROFILES_DIR=.`:
+
+```bash
+cd integration_tests
+dbt deps          # Install package (symlinked to repo root)
+dbt debug         # Verify Snowflake connection
+dbt build         # Run models + tests
+dbt run           # Run models only
+dbt test          # Run tests only
+```
+
+Required env vars for Snowflake: `DBT_SNOWFLAKE_ACCOUNT`, `DBT_SNOWFLAKE_USER`, `DBT_SNOWFLAKE_PASSWORD`, `DBT_SNOWFLAKE_ROLE`, `DBT_SNOWFLAKE_DATABASE`, `DBT_SNOWFLAKE_WAREHOUSE`, `DBT_SNOWFLAKE_SCHEMA`. The job name resolves via fallback chain: `DBT_JOB_NAME` -> `DBT_CLOUD_JOB_ID` -> `UNNAMED_JOB` (warns when `DBT_JOB_NAME` is not set).
+
+Pre-commit hooks: `pip install pre-commit && pre-commit install`
+
+## Architecture
+
+**Core macros** (`macros/set_query_tag.sql`):
+- `set_query_tag(extra={})` — Saves existing session query tag, merges model config tags + session tags + `extra` dict + Yuki standard tags (job name, model, target, invocation ID, etc.), then executes `ALTER SESSION SET QUERY_TAG`. Returns the original tag for restoration.
+- `unset_query_tag(original_query_tag)` — Restores the pre-run session query tag after materialization.
+
+Both use `adapter.dispatch()` so users can override them per-adapter. Users integrate by adding this package to their `dbt_project.yml` dispatch search order, which intercepts dbt's built-in `set_query_tag`/`unset_query_tag` hooks.
+
+**PseudoWarehouse handling**: The macro strips a `PseudoWarehouse` JSON prefix (from Yuki's warehouse-management product) from the existing session tag via regex, preserving data after a `;;` separator.
+
+**Custom extension pattern**: Users override `set_query_tag` in their project and call `yuki_snowflake_dbt_tags.set_query_tag(extra={...})` to inject custom fields while keeping standard Yuki tags.
+
+## Version Management
+
+Version must stay in sync across three files: `dbt_project.yml`, `README.md` (install snippet), and `CHANGELOG.md`. The `scripts/check-version.sh` pre-commit hook enforces consistency, semver format, and that CHANGELOG has a dated entry.
+
+## Integration Tests
+
+Located in `integration_tests/` as a separate dbt project. `integration_tests/dbt_packages/yuki_snowflake_dbt_tags` is a symlink to the repo root, so macro changes are immediately reflected. Three test models verify basic tagging, incremental/full_refresh tagging, and macro compilation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A dbt macro-only package (`yuki_snowflake_dbt_tags`) that automatically tags every Snowflake query during a dbt run with JSON-formatted metadata in the `QUERY_TAG` session parameter. Published on dbt Hub. Current version: 0.2.5.
+A dbt macro-only package (`yuki_snowflake_dbt_tags`) that automatically tags every Snowflake query during a dbt run with JSON-formatted metadata in the `QUERY_TAG` session parameter. Published on dbt Hub.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this package, add the following entry to your `packages.yml` file in 
 ```yaml
 packages:
   - package: YukiTechnologies/yuki_snowflake_dbt_tags
-    version: 0.2.5
+    version: 0.2.6
 ```
 
 ## 🔧 Configuration

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ dispatch:
       - dbt
 ```
 
-**Specifying a Custom Job Name**
+**Specifying a Job Name**
 
-1.	Navigate to: Deploy -> Environments -> Environments Variables.
+The package resolves the job name using the following fallback chain:
+
+1. `DBT_JOB_NAME` environment variable (recommended  - human-readable)
+2. `DBT_CLOUD_JOB_ID` environment variable (automatic in dbt Cloud)
+3. `UNNAMED_JOB` (default if neither is set)
+
+A warning is logged when `DBT_JOB_NAME` is not set.
+
+**Setting `DBT_JOB_NAME` in dbt Cloud:**
+
+1.	Navigate to: Deploy -> Environments -> Environment Variables.
 2.	Click Add variable.
 3.	Fill in the following details:
 
@@ -45,7 +55,7 @@ dispatch:
 Next, configure the job-specific override:
 1.	Go to: Deploy -> Jobs and select the relevant job.
 2.	Navigate to Settings -> Advanced Settings -> Environment Variables.
-3.	Locate `DBT_JOB_NAME` and define a Job override  - this should be the job name.	This job name will be reflected in the Yuki UI.
+3.	Locate `DBT_JOB_NAME` and define a Job override  - this should be the job name. This job name will be reflected in the Yuki UI.
 
 This custom job name will appear in your query tags, making it easier to identify and track specific jobs in the Snowflake query history.
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'yuki_snowflake_dbt_tags'
-version: '0.2.5'
+version: '0.2.6'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -7,7 +7,7 @@ macros:
       including model name, job name, and other contextual information.
 
       This macro generates a JSON query tag with the following fields:
-      - `dbt_job`: Job name from DBT_JOB_NAME environment variable
+      - `dbt_job`: Job name (from DBT_JOB_NAME, falling back to DBT_CLOUD_JOB_ID, then UNNAMED_JOB)
       - `dbt_model`: Name of the current dbt model
       - `dbt_enabled`: Whether Yuki tagging is enabled (from DBT_YUKI_ENABLED)
       - `dbt_target`: The current dbt target name

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -4,8 +4,7 @@
 
 {% macro default__set_query_tag(extra = {}) -%}
   {% set original_query_tag = get_current_query_tag() %}
-  {% set original_query_tag_parsed = {} %}
-  {% set clean_original_query_tag = {} %}
+  {% set clean_original_query_tag = '' %}
   {% set clean_original_query_tag_parsed = {} %}
 
   {% if original_query_tag %}
@@ -22,7 +21,7 @@
   {% set query_tag = config.get('query_tag', default={}) %}
 
   {% if query_tag is not mapping %}
-  {% do log("dbt-snowflake-query-tags warning: the query_tag config value of '{}' is not a mapping type, so is being ignored. If you'd like to add additional query tag information, use a mapping type instead, or remove it to avoid this message.".format(query_tag), True) %}
+  {% do log("yuki-snowflake-dbt-tags warning: the query_tag config value of '{}' is not a mapping type, so is being ignored. If you'd like to add additional query tag information, use a mapping type instead, or remove it to avoid this message.".format(query_tag), True) %}
   {% set query_tag = {} %} {# If the user has set the query tag config as a non mapping type, start fresh #}
   {% endif %}
 
@@ -30,9 +29,15 @@
   {% do query_tag.update(clean_original_query_tag_parsed) %}
   {% do query_tag.update(extra) %}
 
+  {# Resolve dbt job name: DBT_JOB_NAME -> DBT_CLOUD_JOB_ID -> UNNAMED_JOB #}
+  {% set dbt_job_name = env_var('DBT_JOB_NAME', env_var('DBT_CLOUD_JOB_ID', 'UNNAMED_JOB')) %}
+  {% if not env_var('DBT_JOB_NAME', '') %}
+    {% do log("yuki-snowflake-dbt-tags warning: DBT_JOB_NAME is not set, using '{}'. Set DBT_JOB_NAME for readable job names in query tags.".format(dbt_job_name), True) %}
+  {% endif %}
+
   {# Add Yuki query tags #}
   {% do query_tag.update({
-    "dbt_job": env_var('DBT_JOB_NAME'),
+    "dbt_job": dbt_job_name,
     "dbt_model": model.name,
     "dbt_enabled": env_var("DBT_YUKI_ENABLED", "true") | lower == "true",
     "dbt_target": target.name,

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -75,8 +75,8 @@ check_changelog_date() {
 # Extract version from README.md (in the installation section)
 get_readme_version() {
     if [[ -f "README.md" ]]; then
-        # Look for revision field in packages.yml installation examples
-        grep "revision:" README.md | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1
+        # Look for version field in packages.yml installation examples
+        grep "version:" README.md | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1
     fi
 }
 


### PR DESCRIPTION
Enhance job name resolution in query tags by implementing a fallback mechanism. Update the Python version in the CI workflow and synchronize versioning across relevant files. Document these changes in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * DBT_JOB_NAME is now optional with automatic fallback to DBT_CLOUD_JOB_ID, then UNNAMED_JOB.
  * Expanded documentation with detailed job name configuration guidance for dbt Cloud setup.

* **Chores**
  * Version bumped to 0.2.6.
  * Updated CI Python runtime to 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->