### PR TITLE
feat: add upstream dependency info to query tags (v0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-05-26
+
+### Added
+- Upstream dependency info in query tags: `dbt_refs` (list of upstream model names) and `dbt_sources` (list of `source.table` strings) are now included automatically for models, snapshots, and tests. Enables DAG reconstruction directly from Snowflake `QUERY_HISTORY` without uploading `manifest.json`.
+- `DBT_YUKI_DEPS_ENABLED` env var (default `true`) to opt out of dependency tagging.
+- `deps_truncated: true` marker added to the query tag when the full tag would exceed ~1800 characters (protects against failures on models with very many upstream nodes).
+- Integration test models exercising the `ref()` and `source()` code paths.
+
 ## [0.2.6] - 2026-02-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this package, add the following entry to your `packages.yml` file in 
 ```yaml
 packages:
   - package: YukiTechnologies/yuki_snowflake_dbt_tags
-    version: 0.2.6
+    version: 0.2.7
 ```
 
 ## 🔧 Configuration
@@ -66,6 +66,15 @@ If you have a use case where you want the job to run on the original warehouse s
 
 This configuration ensures that the job uses the original warehouse size while bypassing Yuki optimizations.
 
+## 🔗 Dependency Tracking
+
+By default the package includes the current model's upstream `refs` and `sources` in each query tag (`dbt_refs`, `dbt_sources`). This lets you reconstruct your dbt DAG directly from Snowflake's `QUERY_HISTORY` without uploading any artifacts.
+
+To opt out, set:
+
+&nbsp;&nbsp;- Key: `DBT_YUKI_DEPS_ENABLED`
+&nbsp;&nbsp;- Value: `False`
+
 
 ## 🛠 Usage
 
@@ -82,8 +91,12 @@ This configuration ensures that the job uses the original warehouse size while b
   "resource_type": "model",
   "full_refresh": false,
   "materialization": "incremental",
+  "dbt_refs": ["stg_orders", "stg_customers"],
+  "dbt_sources": ["raw.orders"]
 }
 ```
+
+If the tag exceeds ~1800 characters the dep lists are dropped and `"deps_truncated": true` is added instead (rare; only affects models with a very large number of upstream nodes).
 
 This makes it easy to filter and analyze queries by job or model name in Snowflake’s history.
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'yuki_snowflake_dbt_tags'
-version: '0.2.6'
+version: '0.2.7'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"

--- a/integration_tests/models/sources.yml
+++ b/integration_tests/models/sources.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: information_schema
+    schema: information_schema
+    tables:
+      - name: tables

--- a/integration_tests/models/test_deps_downstream.sql
+++ b/integration_tests/models/test_deps_downstream.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('test_deps_upstream') }}

--- a/integration_tests/models/test_deps_upstream.sql
+++ b/integration_tests/models/test_deps_upstream.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select 1 as id, 'upstream' as source_label

--- a/integration_tests/models/test_deps_with_source.sql
+++ b/integration_tests/models/test_deps_with_source.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='table') }}
+
+select table_name
+from {{ source('information_schema', 'tables') }}
+limit 1

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -16,6 +16,9 @@ macros:
       - `resource_type`: Type of dbt resource (model, test, seed, etc.)
       - `full_refresh`: Boolean indicating if this is a full refresh (models only)
       - `materialization`: The materialization type (models only)
+      - `dbt_refs`: List of upstream model names this model refs (models, snapshots, tests; controlled by DBT_YUKI_DEPS_ENABLED)
+      - `dbt_sources`: List of upstream sources in "source.table" format (controlled by DBT_YUKI_DEPS_ENABLED)
+      - `deps_truncated`: Present and true when the tag was too large to include deps (rare; triggered above ~1800 chars)
     arguments:
       - name: extra
         type: dict

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -51,7 +51,38 @@
     ) -%}
   {% endif %}
 
+  {# Add upstream dependency info (refs + sources) when enabled #}
+  {% if env_var("DBT_YUKI_DEPS_ENABLED", "true") | lower == "true" %}
+    {% if model.resource_type in ['model', 'snapshot', 'test'] %}
+      {% set refs_list = [] %}
+      {% for r in (model.refs or []) %}
+        {% if r is mapping %}
+          {% do refs_list.append(r.get('name')) %}
+        {% elif r is sequence and r is not string %}
+          {% do refs_list.append(r[-1]) %}
+        {% else %}
+          {% do refs_list.append(r) %}
+        {% endif %}
+      {% endfor %}
+
+      {% set sources_list = [] %}
+      {% for s in (model.sources or []) %}
+        {% if s is sequence and s is not string and s | length >= 2 %}
+          {% do sources_list.append(s[0] ~ '.' ~ s[1]) %}
+        {% endif %}
+      {% endfor %}
+
+      {% do query_tag.update({"dbt_refs": refs_list, "dbt_sources": sources_list}) %}
+    {% endif %}
+  {% endif %}
+
   {% set query_tag_json = tojson(query_tag) %}
+  {% if query_tag_json | length > 1800 %}
+    {% do query_tag.pop('dbt_refs', none) %}
+    {% do query_tag.pop('dbt_sources', none) %}
+    {% do query_tag.update({"deps_truncated": true}) %}
+    {% set query_tag_json = tojson(query_tag) %}
+  {% endif %}
   {{ log("Setting query_tag to '" ~ query_tag_json ~ "'. Will reset to '" ~ clean_original_query_tag ~ "' after materialization.") }}
   {% do run_query("alter session set query_tag = '{}'".format(query_tag_json)) %}
   {{ return(clean_original_query_tag)}}


### PR DESCRIPTION
## Summary

- Enriches the Snowflake `QUERY_TAG` JSON with `dbt_refs` (list of upstream model names) and `dbt_sources` (list of `source.table` strings) for every model, snapshot, and test materialization
- Enables reconstructing the customer dbt DAG directly from `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY` — no manifest upload, no post-hooks, zero customer effort beyond using the package
- New `DBT_YUKI_DEPS_ENABLED` env var (default `true`) lets customers opt out
- Tags exceeding ~1800 chars drop the dep fields and emit `"deps_truncated": true` to avoid breaking wide models
- Handles both old and new dbt ref shapes (list vs dict) defensively for cross-version compatibility

## Example query tag output

```json
{
  "dbt_job": "my_job",
  "dbt_model": "fct_orders",
  "dbt_refs": ["stg_orders", "stg_customers"],
  "dbt_sources": ["raw.orders"],
  "dbt_target": "prod",
  "invocation_id": "c5faa810-...",
  "run_cmd": "build",
  "resource_type": "model",
  "full_refresh": false,
  "materialization": "incremental"
}
```

## Test plan

- [ ] `dbt run --select test_deps_downstream` → confirm `dbt_refs: ["test_deps_upstream"]` in QUERY_HISTORY
- [ ] `dbt run --select test_deps_with_source` → confirm `dbt_sources: ["information_schema.tables"]` in QUERY_HISTORY
- [ ] `DBT_YUKI_DEPS_ENABLED=false dbt run` → confirm no `dbt_refs`/`dbt_sources` keys in tag
- [ ] Existing models with no refs → confirm `dbt_refs: []`, `dbt_sources: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic inclusion of upstream model references and sources in query tags
  * Added `DBT_YUKI_DEPS_ENABLED` environment variable (enabled by default) to control dependency tracking
  * Graceful tag truncation with `deps_truncated` flag when size exceeds ~1800 characters

* **Documentation**
  * Updated README to document new dependency tracking behavior and environment variable configuration

* **Tests**
  * Added integration tests covering upstream model references and source dependencies

* **Chores**
  * Version bumped to 0.2.7

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YukiTechnologies/yuki-snowflake-dbt-tags/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->