### PR TITLE
feat: add build_query_tag macro for single ALTER SESSION composition (YU-1877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-08
+
+### Added
+- New `build_query_tag(extra={})` macro that returns the merged query tag (`{"query_tag": ..., "original_query_tag": ...}`) **without** executing `ALTER SESSION`. Lets projects compose Yuki's tags with another query-tagging package in a single `ALTER SESSION` while keeping Yuki authoritative over `PseudoWarehouse` parsing/stripping. `set_query_tag` now delegates to it; its behavior is unchanged.
+- README: new "Composing With Another Query-Tagging Package" section documenting the single-`ALTER SESSION` chaining pattern via `build_query_tag`.
+
 ## [0.3.0] - 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this package, add the following entry to your `packages.yml` file in 
 ```yaml
 packages:
   - package: YukiTechnologies/yuki_snowflake_dbt_tags
-    version: 0.3.0
+    version: 0.3.1
 ```
 
 ## 🔧 Configuration
@@ -112,6 +112,36 @@ Use the `extra` kwarg on `set_query_tag` to add your own key/value pairs while k
 ```
 
 Calling the package macros keeps the built-in metadata and simply adds your custom fields.
+
+## 🔗 Composing With Another Query-Tagging Package
+
+dbt's Snowflake adapter calls a single `set_query_tag` hook per node, so if you use this package alongside **another package that also overrides `set_query_tag`**, only one can win — and naively chaining them runs `ALTER SESSION` twice per node. The other package also won't understand this package's `PseudoWarehouse` session-tag format (`{"PseudoWarehouse":…};;{…}`), so it can drop the prefix and anything after `;;`.
+
+Use **`build_query_tag`** to compose them with a single `ALTER SESSION`. It runs all of this package's logic — including the `PseudoWarehouse` parse/strip — and returns the merged tag **without** touching the session:
+
+```jinja
+{{ build_query_tag(extra={}) }}
+-- {"query_tag": {<merged tag dict>}, "original_query_tag": "<cleaned original, to restore>"}
+```
+
+Define a project-level override (resolved ahead of both packages) that lets this package build the tag, then hands the result to the other package as its `extra` so it performs the one and only `ALTER SESSION`:
+
+```jinja
+{% macro set_query_tag(extra = {}) -%}
+  {# This package builds the tag (and strips its PseudoWarehouse prefix) without
+     altering the session. The other package then does the single ALTER SESSION,
+     layering its own fields on top. #}
+  {% set built = yuki_snowflake_dbt_tags.build_query_tag(extra=extra) %}
+  {% do your_other_query_tagging_package.set_query_tag(extra=built["query_tag"]) %}
+  {{ return(built["original_query_tag"]) }}
+{% endmacro %}
+
+{% macro unset_query_tag(original_query_tag) -%}
+  {% do return(yuki_snowflake_dbt_tags.unset_query_tag(original_query_tag)) %}
+{% endmacro %}
+```
+
+This keeps this package authoritative over `PseudoWarehouse` handling and restore semantics, while the other package's fields are merged in — all in one session update. Because this package returns an already-cleaned dict, the other package never has to parse the raw `PseudoWarehouse` tag.
 
 ## 📄 License
 This package is open-source under the MIT License. See the LICENSE file for details.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'yuki_snowflake_dbt_tags'
-version: '0.3.0'
+version: '0.3.1'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -21,6 +21,23 @@ macros:
         type: dict
         description: Additional key-value pairs to include in the query tag (optional)
 
+  - name: build_query_tag
+    description: |
+      Builds the same query tag as `set_query_tag` but WITHOUT executing
+      `ALTER SESSION`. Returns a mapping with two keys:
+      - `query_tag`: the merged tag dict (model config + session tag + `extra` + Yuki fields)
+      - `original_query_tag`: the value to restore afterwards, with any Yuki
+        `PseudoWarehouse` prefix already stripped
+
+      Use this to compose Yuki's tags with another query-tagging package in a
+      single `ALTER SESSION`: call `build_query_tag` to let Yuki parse/strip the
+      session tag, then pass the resulting `query_tag` as the other package's
+      `extra` so it performs the one and only session update.
+    arguments:
+      - name: extra
+        type: dict
+        description: Additional key-value pairs to include in the query tag (optional)
+
   - name: unset_query_tag
     description: |
       Resets the Snowflake query tag to its original value after a model has been materialized.
@@ -29,6 +46,9 @@ macros:
       - name: original_query_tag
         type: string
         description: The original query tag to restore
+
+  - name: default__build_query_tag
+    description: Default implementation of build_query_tag for Snowflake adapter
 
   - name: default__set_query_tag
     description: Default implementation of set_query_tag for Snowflake adapter

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -2,7 +2,15 @@
   {{ return(adapter.dispatch('set_query_tag', 'yuki_snowflake_dbt_tags')(extra=extra)) }}
 {%- endmacro %}
 
-{% macro default__set_query_tag(extra = {}) -%}
+{# Builds the query tag WITHOUT touching the session, so callers can compose it
+   with other tagging packages and run a single `ALTER SESSION`. Returns a mapping
+   with `query_tag` (the merged tag dict) and `original_query_tag` (the value to
+   restore afterwards, with any Yuki PseudoWarehouse prefix already stripped). #}
+{% macro build_query_tag(extra = {}) -%}
+  {{ return(adapter.dispatch('build_query_tag', 'yuki_snowflake_dbt_tags')(extra=extra)) }}
+{%- endmacro %}
+
+{% macro default__build_query_tag(extra = {}) -%}
   {% set original_query_tag = get_current_query_tag() %}
   {% set clean_original_query_tag = '' %}
   {% set clean_original_query_tag_parsed = {} %}
@@ -62,10 +70,15 @@
     ) -%}
   {% endif %}
 
-  {% set query_tag_json = tojson(query_tag) %}
-  {{ log("Setting query_tag to '" ~ query_tag_json ~ "'. Will reset to '" ~ clean_original_query_tag ~ "' after materialization.") }}
+  {{ return({"query_tag": query_tag, "original_query_tag": clean_original_query_tag}) }}
+{% endmacro %}
+
+{% macro default__set_query_tag(extra = {}) -%}
+  {% set built = yuki_snowflake_dbt_tags.build_query_tag(extra=extra) %}
+  {% set query_tag_json = tojson(built["query_tag"]) %}
+  {{ log("Setting query_tag to '" ~ query_tag_json ~ "'. Will reset to '" ~ built["original_query_tag"] ~ "' after materialization.") }}
   {% do run_query("alter session set query_tag = '{}'".format(query_tag_json)) %}
-  {{ return(clean_original_query_tag)}}
+  {{ return(built["original_query_tag"])}}
 {% endmacro %}
 
 {% macro unset_query_tag(original_query_tag) -%}


### PR DESCRIPTION
## What

Adds a new **`build_query_tag(extra={})`** macro that runs all of Yuki's tag-building logic — including the `PseudoWarehouse` strip — and returns the merged tag **without** executing `ALTER SESSION`:

```jinja
{{ build_query_tag() }}  -> {"query_tag": {...}, "original_query_tag": "<cleaned original>"}
```

`set_query_tag` now delegates to it, so its behavior is **unchanged** for standalone users.

## Why

When a project layers Yuki with another query-tagging package, both packages' `set_query_tag` each execute their own `ALTER SESSION` — two session updates per node, and the other package can't parse Yuki's `{"PseudoWarehouse":…};;{…}` session-tag format.

With `build_query_tag`, a consumer lets Yuki parse/strip the session tag and build the dict, then hands that dict to the other package as its `extra` so it performs the **single** `ALTER SESSION`. Yuki stays authoritative over `PseudoWarehouse` handling, and there's only one session update.

## Compatibility

- `set_query_tag` / `unset_query_tag` behavior unchanged (verified: same tag, same restore value).
- Version bumped 0.3.0 → **0.3.1** (additive macro, no behavior change). README + CHANGELOG updated; `build_query_tag` documented in `macros/schema.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper that returns merged query-tag data (merged tag + original tag) without modifying session state.

* **Refactor**
  * Session tag-setting now reuses the new helper for tag construction while preserving prior runtime behavior.

* **Documentation**
  * Docs and changelog explain composing this package with other taggers to ensure a single ALTER SESSION and preserve tag restore behavior.

* **Chores**
  * Bumped project/package version to 0.3.1 and updated installation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->