### PR TITLE
fix: annotate extra as dict[string, any] so dbt accepts the type (YU-2452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-08-05
+
+### Fixed
+- `extra` is now annotated as `dict[string, any]` in `macros/schema.yml`. dbt's macro-argument validator accepts `dict` only with its two type parameters, so bare `dict` made every parse of a consuming project emit `Argument extra in the yaml for macro set_query_tag has an invalid type.` (and the same for `build_query_tag` since 0.3.1). Annotation only; no macro behavior changes.
+
 ## [0.3.1] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this package, add the following entry to your `packages.yml` file in 
 ```yaml
 packages:
   - package: YukiTechnologies/yuki_snowflake_dbt_tags
-    version: 0.3.1
+    version: 0.3.2
 ```
 
 ## 🔧 Configuration

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'yuki_snowflake_dbt_tags'
-version: '0.3.1'
+version: '0.3.2'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -18,7 +18,7 @@ macros:
       - `materialization`: The materialization type (models only)
     arguments:
       - name: extra
-        type: dict
+        type: dict[string, any]
         description: Additional key-value pairs to include in the query tag (optional)
 
   - name: build_query_tag
@@ -35,7 +35,7 @@ macros:
       `extra` so it performs the one and only session update.
     arguments:
       - name: extra
-        type: dict
+        type: dict[string, any]
         description: Additional key-value pairs to include in the query tag (optional)
 
   - name: unset_query_tag


### PR DESCRIPTION
## Summary

Every `dbt parse` in a consuming project emits:

```
WARNING: Argument extra in the yaml for macro set_query_tag has an invalid type.
WARNING: Argument extra in the yaml for macro build_query_tag has an invalid type.
```

dbt's macro-argument validator (`dbt/parser/schemas.py`, `macro_types`) treats `dict` as a **2-parameter** type: bare `dict` fails `match_arg_list`, which needs `[keytype, valuetype]`. `string` and `any` take 0 parameters, so `dict[string, any]` validates. That matches what `extra` actually is: string keys, arbitrary values.

The second warning arrived with 0.3.1, which added `build_query_tag` carrying the same annotation.

Annotation only. No macro behavior changes, no signature changes.

Version bumped 0.3.1 → 0.3.2 with a CHANGELOG entry, per the repo's `scripts/check-version.sh` contract.

## Test plan

- [x] `bash scripts/check-version.sh` → all version checks pass, ready for release v0.3.2
- [x] Applied the fixed `macros/schema.yml` to `dbt-dwh-etl`'s installed copy and ran `dbt parse --no-partial-parse` on **dbt-core 1.12.0**: both warnings gone, parse fully clean
- [x] Committed file is byte-identical to the copy that parsed clean
- [ ] Not run: `integration_tests` (needs Snowflake credentials; no macro code changed)

## Follow-up

Needs a `v0.3.2` tag + GitHub release for hubcap to publish it to dbt Hub, then `dbt-dwh-etl`'s `packages.yml` can move off 0.3.1. Not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpNpxmDMk9R6jTGmn1BFvr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro argument validation errors by clarifying that `extra` accepts string-keyed dictionaries with values of any type.
  * Macro behavior remains unchanged.

* **Documentation**
  * Updated the package and project version to 0.3.2.
  * Added a changelog entry describing the validation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->